### PR TITLE
fix: fallback bf16 dot to FMA on sm75 (Turing MMA only supports fp16)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -61,8 +61,16 @@ static int getMMAVersionSafe(int computeCapability, DotOp op) {
     assert(false && "computeCapability not supported");
   }
   for (int baseVersion : versionsSupported) {
-    if (supportMMA(op, baseVersion))
+    if (supportMMA(op, baseVersion)) {
+      // Turing (sm75) MMA only supports fp16; bf16 requires Ampere+.
+      if (computeCapability < 80) {
+        auto aElemTy = op.getA().getType().getElementType();
+        auto bElemTy = op.getB().getType().getElementType();
+        if (aElemTy.isBF16() || bElemTy.isBF16())
+          continue;
+      }
       return baseVersion;
+    }
     if (baseVersion == 3) {
       auto remark = op.emitRemark()
                     << "MMA version 3 acceleration not applied due to "


### PR DESCRIPTION
  ## Summary
  - Turing MMA only supports fp16, not bf16 (bf16 MMA requires Ampere+)
  - `supportMMA()` incorrectly returned true for bf16 on sm75, causing `ConvertTritonGPUToLLVM` crash
  - Skip MMA for bf16 when `computeCapability < 80`, fallback to FMA

  ## Test
  - `test_pipeliner.py`: 29 passed (including bf16 indirect_matmul), 7 skipped, 0 failed
  - Previously 9 bf16 tests failed with "unsupported MMA instruction"