### PR TITLE
fix: reorder createSyncCopy to preserve global load data flow

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -160,23 +160,25 @@ void createSyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   OpBuilder::InsertionGuard guard(builder);
   Location loc = loadOp.getLoc();
 
-  // producer: reg -> shared, then barrier
-  builder.setInsertionPoint(loadOp);
-  builder.setStageCluster(schedule[loadOp]);
-  Value view = createSingleBufferView(builder, alloc, insertIdx);
-  ttg::LocalStoreOp::create(builder, loadOp.getResult(), view);
-  ttg::BarrierOp::create(builder, loc,
-                         ttg::AddrSpace::Local);
-
-  // consumer: local_load, then barrier to prevent producer overwrite
+  // consumer: local_load, then barrier to prevent producer overwrite.
+  // The original uses must be replaced before creating the local_store:
+  // replaceUsesWithLocalLoad rewrites all existing uses of loadOp, so a
+  // local_store created earlier would have its operand rewritten to the
+  // local_load result, losing the global load data.
+  builder.setInsertionPoint(firstUse);
   builder.setStageCluster(schedule[firstUse]);
   auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
   replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad, nullptr);
-  ttg::BarrierOp::create(builder, loc,
-                         ttg::AddrSpace::Local);
+  ttg::BarrierOp::create(builder, loc, ttg::AddrSpace::Local);
 
-  schedule.erase(loadOp);
-  loadOp->erase();
+  // producer: reg -> shared, then barrier. Unlike the async path, loadOp
+  // stays alive: the local_store consumes its result and PipelineExpander
+  // still needs its stage in the schedule.
+  builder.setInsertionPointAfter(loadOp);
+  builder.setStageCluster(schedule[loadOp]);
+  Value view = createSingleBufferView(builder, alloc, insertIdx);
+  ttg::LocalStoreOp::create(builder, loadOp.getResult(), view);
+  ttg::BarrierOp::create(builder, loc, ttg::AddrSpace::Local);
 }
 
 void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,


### PR DESCRIPTION
## Problem

`createSyncCopy()` (introduced in #3) had a correctness bug that broke the data flow of the sm75 synchronous copy pipeline: 1. It first created a `LocalStoreOp` whose operand is `loadOp.getResult()`, making the store a user of `loadOp`. 2. It then called `replaceUsesWithLocalLoad`, whose internal `replaceAllUsesWith` rewrites **all** existing uses of the load result — including the just-created `LocalStoreOp`. The store's operand was rewritten to the `local_load` result, turning it into a shared→shared self-loop: the global load data never reached shared memory. The trailing `loadOp->erase()` then deleted the actual data source (`ld.global`) along with the schedule info that `PipelineExpander` needs. The async path does not have this problem: `AsyncCopyGlobalToLocalOp` reads `loadOp.getPtr()` (the pointer, not the result), so the use replacement never touches it, and erasing the fully-replaced load is correct. The sync path copied that structure without accounting for the operand difference.

## Fix

Swap the consumer/producer order and keep `loadOp` alive: **Consumer first**: insert `local_load` + barrier at `firstUse` and replace the original uses while they are still the only users of `loadOp`. **Producer second**: insert `local_store` + barrier **after** `loadOp` (SSA: the store consumes the load result, so it cannot precede it). Being a new use, it is unaffected by the already-completed replacement. **Keep `loadOp`**: the `local_store` consumes its result, and `PipelineExpander` still needs its stage in the schedule for cross-stage reordering.

## Testing

- `pytest python/test/unit/language/test_pipeliner.py` passes on Turing (sm75).
- End-to-end GEMM numerical check (`03-matrix-multiplication.py`) matches `torch.mm` (cuBLAS).