### PR TITLE
feat: enable software pipelining passes for sm75

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -175,7 +175,9 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   if (isConstantIntValue(pred, 1))
     return op;
-  if (isa<LLVM::AssumeOp, ttng::FenceAsyncSharedOp>(op))
+  // BarrierOp must execute uniformly across the CTA, so it cannot be
+  // predicated; running it for masked-off stages is safe.
+  if (isa<LLVM::AssumeOp, ttng::FenceAsyncSharedOp, ttg::BarrierOp>(op))
     return op;
   if (isa<ttg::AsyncCommitGroupOp, ttg::AsyncWaitOp>(op))
     return op;

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -426,6 +426,8 @@ def indirect_matmul_kernel(
 def test_indirect_matmul(BLOCK_M, BLOCK_N, BLOCK_K, num_stages, device):
     if (num_stages > 3 or (num_stages >= 3 and (BLOCK_M, BLOCK_N, BLOCK_K) == (128, 128, 128))) and is_hip():
         pytest.skip("Not enough shared memory on HIP.")
+    if num_stages >= 3 and is_cuda() and torch.cuda.get_device_capability() == (7, 5):
+        pytest.skip("Multibuffering at these block sizes exceeds Turing's 64KB shared memory per CTA.")
     M = BLOCK_M
     N = BLOCK_N
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -305,6 +305,18 @@ class CUDABackend(BaseBackend):
             # hoist again and allow hoisting out of if statements
             passes.ttgpuir.add_hoist_tmem_alloc(pm, True)
             nvidia.passes.ttnvgpuir.add_remove_tmem_tokens(pm)
+        elif capability == 75:
+            # Turing: same pipelining flow as Ampere/Hopper but without
+            # warp specialization. LowerLoops routes to the synchronous
+            # copy path (no cp.async on sm75).
+            passes.ttgpuir.add_fuse_nested_loops(pm)
+            passes.common.add_canonicalizer(pm)
+            passes.ttir.add_triton_licm(pm)
+            passes.common.add_canonicalizer(pm)
+            passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+            passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
+            passes.ttgpuir.add_schedule_loops(pm)
+            passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
         else:
             passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)


### PR DESCRIPTION
## Problem

The sm75 synchronous copy path (#3, #5) was effectively unreachable in the compilation pipeline. `compiler.py` only scheduled the pipelining passes (`assign_latencies`, `schedule_loops`, and `pipeline`) for capabilities 8.x/9.x (Ampere/Hopper) and 10.x+ (Blackwell), while sm75 fell into the fallback branch and never invoked the pipeliner. As a result, previous sm75 test coverage was misleading since pipelining was never actually exercised.

Once the passes are enabled, the pipeline expander predicates stage-local operations through `predicateOp`, which maintains a whitelist and aborts on unknown side-effecting operations. `ttg.barrier` was missing from this list.

## Changes

* Add a dedicated `capability == 75` branch in `compiler.py` that uses the same pipelining flow as Ampere/Hopper (fuse nested loops → LICM → assign latencies → schedule loops → pipeline), excluding `hopper_warpspec`. LowerLoops already routes sm75 to the synchronous copy implementation internally.
* Update `PipeliningUtility.cpp` so that `predicateOp` treats `ttg::BarrierOp` the same way as `FenceAsyncSharedOp`, leaving it unpredicated. Since `bar.sync` must execute uniformly across the CTA, predicating it would be incorrect. Executing it in masked-off stages is harmless and only incurs a small synchronization overhead.
* Skip `test_indirect_matmul` with `num_stages >= 3` on sm75 in `test_pipeliner.py`. These configurations exceed Turing's 64 KB shared-memory-per-CTA limit when multibuffering is enabled. The skip mirrors the existing HIP restriction. Previously these cases appeared to pass only because pipelining was never activated.

## Testing

* Verified on Turing that pipelined matmul TTGIR expands correctly with `num_stages=2`, producing the expected `local_store` and `ttg.barrier` operations. Numerical results match `torch.mm`.
* `test_pipeliner.py`: 26 passed, 10 skipped (including 6 new sm75 capacity skips), 0 failed.
* `03-matrix-multiplication.py`: fp16 and fp8 results match PyTorch. With pipelining enabled, fp16 performance reaches ~36 TFLOPS versus ~80 TFLOPS for cuBLAS. Current autotuning configurations remain Ampere-oriented; Turing-specific tuning is left for follow-up work.
