### PR TITLE
test: add SM75 sync copy lit tests and fix 3 related bugs

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1530,6 +1530,10 @@ void BarrierOp::print(OpAsmPrinter &p) {
   } else {
     p << ' ' << stringifyAddrSpace(getAddrSpace());
   }
+  // Discardable attrs (e.g. the pipeliner's loop.stage/loop.cluster) must be
+  // printed or they are lost on a textual round-trip. addrSpace is already
+  // printed as the keyword above.
+  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"addrSpace"});
 }
 
 ParseResult BarrierOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -1562,6 +1566,9 @@ ParseResult BarrierOp::parse(OpAsmParser &parser, OperationState &result) {
 
   result.addAttribute("addrSpace",
                       AddrSpaceAttr::get(parser.getContext(), addrSpaceRet));
+
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
 
   return success();
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -168,7 +168,15 @@ void createSyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   builder.setInsertionPoint(firstUse);
   builder.setStageCluster(schedule[firstUse]);
   auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
-  replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad, nullptr);
+  auto localLoad =
+      replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad, nullptr);
+  // replaceUsesWithLocalLoad erases local_alloc users it folds into the
+  // pipeline buffer, which may include firstUse; anchor the barrier on ops we
+  // created ourselves instead of the (possibly dangling) insertion point.
+  if (localLoad)
+    builder.setInsertionPointAfter(localLoad);
+  else
+    builder.setInsertionPointAfter(viewLoad.getDefiningOp());
   ttg::BarrierOp::create(builder, loc, ttg::AddrSpace::Local);
 
   // producer: reg -> shared, then barrier. Unlike the async path, loadOp
@@ -1100,7 +1108,13 @@ void lowerLoop(scf::ForOp forOp,
 
 void lowerLoops(ModuleOp moduleOp) {
   triton::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
-  int computeCapability = getNVIDIAComputeCapability(moduleOp);
+  // The module may target another vendor or, in lit tests, carry no target
+  // attribute at all; getNVIDIAComputeCapability asserts on both. Treat them
+  // as "not sm75" so only Turing modules take the sync copy path.
+  int computeCapability = 0;
+  auto targetAttr = moduleOp->getAttrOfType<StringAttr>(AttrTargetName);
+  if (targetAttr && targetAttr.getValue().starts_with("cuda:"))
+    computeCapability = getNVIDIAComputeCapability(moduleOp);
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
   if (loops.empty())

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -626,16 +626,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+// Turing fork: fp16 dots on sm75 use MMA v2 instead of the upstream FMA fallback.
+// CHECK: #[[$MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 1, warpsPerCTA = [2, 4], instrShape = [16, 8]}>
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:75", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: dot_fall_back_fma_before_ampere
-  tt.func public @dot_fall_back_fma_before_ampere(%arg0: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<128x256x!tt.ptr<f32>, #blocked>) {
+  // CHECK-LABEL: dot_mma_on_turing
+  tt.func public @dot_mma_on_turing(%arg0: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<128x256x!tt.ptr<f32>, #blocked>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
-    // CHECK:   %[[EXT0:.*]] = arith.extf %arg0
-    // CHECK:   %[[EXT1:.*]] = arith.extf %arg1
-    // CHECK:   %[[DOT:.*]] = tt.dot %[[EXT0]], %[[EXT1]]
+    // CHECK:   %[[A:.*]] = ttg.convert_layout %arg0 : {{.*}} -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$MMA]], kWidth = 2}>>
+    // CHECK:   %[[B:.*]] = ttg.convert_layout %arg1 : {{.*}} -> tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$MMA]], kWidth = 2}>>
+    // CHECK:   %[[DOT:.*]] = tt.dot %[[A]], %[[B]], %{{.*}} -> tensor<128x256xf32, #[[$MMA]]>
     %0 = tt.dot %arg0, %arg1, %cst, inputPrecision = tf32 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x256xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x256xf32, #blocked>
-    // CHECK:   tt.store %arg2, %[[DOT]]
+    // CHECK:   %[[RES:.*]] = ttg.convert_layout %[[DOT]] : tensor<128x256xf32, #[[$MMA]]> -> tensor<128x256xf32, #blocked>
+    // CHECK:   tt.store %arg2, %[[RES]]
     tt.store %arg2, %0 : tensor<128x256x!tt.ptr<f32>, #blocked>
     tt.return
   }

--- a/test/TritonGPU/pipeline-schedule-loop.mlir
+++ b/test/TritonGPU/pipeline-schedule-loop.mlir
@@ -863,3 +863,26 @@ tt.func public @backwards_prop_existing(%arg0: i32, %arg1: tensor<128x4x!tt.ptr<
 }
 
 }
+
+// -----
+
+#blocked_skip = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+// Loops that already contain a CTA barrier are not safe to reorder across
+// stages; isSafeToPipeline must skip them without assigning any schedule.
+// CHECK-LABEL: @skip_loop_with_handwritten_barrier
+// CHECK-NOT: loop.stage
+// CHECK-NOT: tt.scheduled_max_stage
+tt.func @skip_loop_with_handwritten_barrier(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked_skip>) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {tt.latency = 2 : i32} : tensor<128x32x!tt.ptr<f16>, #blocked_skip>
+    ttg.barrier local
+    "use"(%a) : (tensor<128x32xf16, #blocked_skip>) -> ()
+  }
+  tt.return
+}
+
+}

--- a/test/TritonGPU/sm75-sync-copy-lower-loop.mlir
+++ b/test/TritonGPU/sm75-sync-copy-lower-loop.mlir
@@ -1,0 +1,99 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-lower-loop -canonicalize | FileCheck %s
+
+// Turing (sm75) has no cp.async. LowerLoops routes loads to the synchronous
+// copy path: the global tt.load is kept alive as the data source, its result
+// is staged through shared memory with local_store/local_load, and CTA-wide
+// ttg.barrier ops synchronize the producer and consumer sides.
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// The local_store must consume the tt.load result (not the local_load
+// result), and both barriers must carry the schedule of their side.
+// CHECK-LABEL: @sync_copy_dataflow
+// CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x128x32
+// CHECK: scf.for
+// CHECK:   %[[LOAD:.*]] = tt.load %{{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   %[[INS:.*]] = ttg.memdesc_index %[[ALLOC]]{{\[}}%{{.*}}{{\]}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.local_store %[[LOAD]], %[[INS]] {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.barrier local {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   %[[EXT:.*]] = ttg.memdesc_index %[[ALLOC]]{{\[}}%{{.*}}{{\]}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK:   %[[VAL:.*]] = ttg.local_load %[[EXT]] {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK:   ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK:   "use"(%[[VAL]])
+// CHECK: ttg.local_dealloc %[[ALLOC]]
+tt.func @sync_copy_dataflow(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
+  } {tt.scheduled_max_stage = 2 : i32}
+  tt.return
+}
+}
+
+// -----
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// When the load feeds a local_alloc with a matching shared encoding,
+// replaceUsesWithLocalLoad folds the alloc into the pipeline buffer: the
+// consumer reads the buffer view directly, no local_load is created, and the
+// original local_alloc disappears. This path used to crash with a dangling
+// insertion point because the alloc (the load's first use) is erased.
+// CHECK-LABEL: @sync_copy_local_alloc_user
+// CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x128x32
+// CHECK: scf.for
+// CHECK:   %[[LOAD:.*]] = tt.load %{{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.local_store %[[LOAD]], %{{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.barrier local {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   %[[EXT:.*]] = ttg.memdesc_index %[[ALLOC]]{{\[}}%{{.*}}{{\]}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK-NOT: ttg.local_load
+// CHECK-NOT: ttg.local_alloc
+// CHECK:   ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK:   "use"(%[[EXT]])
+tt.func @sync_copy_local_alloc_user(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    %sh = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> !ttg.memdesc<128x32xf16, #shared, #smem>
+    "use"(%sh) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (!ttg.memdesc<128x32xf16, #shared, #smem>) -> ()
+  } {tt.scheduled_max_stage = 2 : i32}
+  tt.return
+}
+}
+
+// -----
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// Multibuffering beyond double buffering: a stage distance of 3 must allocate
+// 3 slots and rotate both the insert and the extract index modulo 3, on
+// distinct index chains.
+// CHECK-LABEL: @sync_copy_three_stages
+// CHECK-DAG: %[[BUFS:.*]] = arith.constant {{.*}} 3 : i32
+// CHECK-DAG: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<3x128x32
+// CHECK: scf.for
+// CHECK:   arith.cmpi sge, %{{.*}}, %[[BUFS]] {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   %[[INSIDX:.*]] = arith.select %{{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   arith.cmpi sge, %{{.*}}, %[[BUFS]] {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+// CHECK:   %[[EXTIDX:.*]] = arith.select %{{.*}} {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+// CHECK:   ttg.memdesc_index %[[ALLOC]]{{\[}}%[[INSIDX]]{{\]}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.local_store
+// CHECK:   ttg.barrier local {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:   ttg.memdesc_index %[[ALLOC]]{{\[}}%[[EXTIDX]]{{\]}} {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+// CHECK:   ttg.local_load
+// CHECK:   ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+tt.func @sync_copy_three_stages(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    "use"(%a) {loop.cluster = 0 : i32, loop.stage = 3 : i32} : (tensor<128x32xf16, #A>) -> ()
+  } {tt.scheduled_max_stage = 3 : i32}
+  tt.return
+}
+}

--- a/test/TritonGPU/sm75-sync-copy-pipeline.mlir
+++ b/test/TritonGPU/sm75-sync-copy-pipeline.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-pipeline | FileCheck %s
+
+// Full software pipelining on sm75: the expander must peel a prologue that
+// prefills the buffer slots, predicate the loads via their mask operand, and
+// leave every ttg.barrier unpredicated at the top level of the loop body.
+// bar.sync must execute uniformly across the CTA: wrapping it in control flow
+// would deadlock, and predicateOp would abort compilation if it did not
+// whitelist BarrierOp.
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// CHECK-LABEL: @sync_copy_expand
+// CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x128x32
+
+// Prologue: two prefill iterations, each load masked by a trip-count guard.
+// CHECK: tt.load %{{.*}}, %{{.*}} : tensor<128x32x!tt.ptr<f16>
+// CHECK: ttg.local_store
+// CHECK: ttg.barrier local
+// CHECK: tt.load %{{.*}}, %{{.*}} : tensor<128x32x!tt.ptr<f16>
+// CHECK: ttg.local_store
+// CHECK: ttg.barrier local
+
+// Kernel: consumer side first (local_load + barrier), then the next tile's
+// masked load and store. No op may be wrapped in control flow, and no
+// unresolved ttg.mask may survive.
+// CHECK: scf.for
+// CHECK-NOT: scf.if
+// CHECK-NOT: ttg.mask
+// CHECK:   %[[VAL:.*]] = ttg.local_load
+// CHECK-NOT: scf.if
+// CHECK:   ttg.barrier local
+// CHECK-NOT: scf.if
+// CHECK:   "use"(%[[VAL]])
+// CHECK-NOT: scf.if
+// CHECK:   tt.load %{{.*}}, %{{.*}} : tensor<128x32x!tt.ptr<f16>
+// CHECK-NOT: scf.if
+// CHECK:   ttg.local_store
+// CHECK-NOT: scf.if
+// CHECK:   ttg.barrier local
+// CHECK-NOT: scf.if
+// CHECK-NOT: ttg.mask
+// CHECK:   scf.yield
+// CHECK: ttg.local_dealloc %[[ALLOC]]
+tt.func @sync_copy_expand(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
+  } {tt.scheduled_max_stage = 2 : i32}
+  tt.return
+}
+}


### PR DESCRIPTION
## Summary

Adds the lit test coverage planned as PR 3 for the sm75 synchronous copy pipeline. Writing the tests immediately caught three real bugs, all fixed here; each fix is a separate commit.

## Bugs found and fixed

1. **`ttg.barrier` printer dropped discardable attrs** (`651535352`). The custom printer only emitted the addrSpace keyword, so the pipeliner's `loop.stage`/`loop.cluster` vanished from pretty-printed IR and were lost on textual round-trips. In-memory compilation was unaffected, but IR dumps misleadingly showed unscheduled barriers and FileCheck could not assert barrier scheduling.

2. **`lowerLoops` crashed on modules without a CUDA target** (`f3727b4c2`). `getNVIDIAComputeCapability` asserts when `ttg.target` is missing (most lit tests) or non-CUDA (`hip:*`). Four upstream lit tests (`loop-pipeline`, `loop-pipeline-cuda`, `loop-pipeline-hopper`, `pipeline-lower-loop`) had been crashing since the sync copy landed—unnoticed because the lit suite had never been run. The target is now read defensively.

3. **Segfault on the local_alloc-elision path** (`f3727b4c2`). `createSyncCopy` pinned its insertion point on `firstUse`, but `replaceUsesWithLocalLoad` erases local_alloc users it folds into the pipeline buffer—including `firstUse`—leaving a dangling insertion point. This is the path real GEMM kernels take (dot operands live in shared memory); the ignition test survived only by UB luck. The consumer barrier is now anchored on ops we create ourselves.

## Test coverage added

* `sm75-sync-copy-lower-loop.mlir`: dataflow regression (local_store consumes the tt.load result), local_alloc-elision path (no local_load, consumer reads the pipeline buffer view), and 3-stage slot rotation (3-slot alloc with insert/extract chains modulo 3 on distinct indices).
* `sm75-sync-copy-pipeline.mlir`: full expansion; prologue prefills both slots with mask-predicated loads, barriers stay unpredicated at loop-body top level, no `ttg.mask` survives, and the RUN line itself guards the predicateOp whitelist (compilation aborts without it).
* `pipeline-schedule-loop.mlir`: loops with handwritten barriers are skipped by `isSafeToPipeline`.
* `accelerate-matmul.mlir`: replaces the stale upstream expectation (sm75 falls back to FMA) with this fork's intended behavior (fp16 → MMA v2, instrShape `[16, 8]`).

## Testing

* lit: 280/280 pass (was 273/278 before the fixes)
* Turing GPU: ignition test numerics OK; `test_pipeliner.py` 23 passed / 13 skipped / 0 failed; `03-matrix-multiplication` fp16+fp8 results match Torch, and fp16 performance is unchanged vs PR 2 (~36 TFLOPS at large sizes)
