### PR TITLE
test: add sm75 pipeline correctness stress suite

### DIFF
--- a/python/test/unit/language/test_pipeliner_sm75.py
+++ b/python/test/unit/language/test_pipeliner_sm75.py
@@ -1,0 +1,110 @@
+# Stress tests for the sm75 synchronous-copy software pipeline.
+#
+# These tests run on any CUDA arch (on Ampere+ they exercise the async copy
+# path), but they were written to pin down Turing-specific risks:
+# - masked-off pipeline stages still execute local_store unconditionally
+#   (predicateOp whitelists it); the garbage they write must only ever land
+#   in slots whose consumers are also masked off. Tiny and degenerate trip
+#   counts are where this breaks.
+# - multibuffer slot rotation (num_stages > 2) must never map two live
+#   stages to the same slot. Deterministic integer data makes a clobbered
+#   tile show up as an exact mismatch instead of a tolerance blip.
+# - the sync path keeps the original tt.load alive, so mask + non-zero
+#   `other` semantics must survive pipelining without the async path's
+#   select special-case.
+#
+# All comparisons are exact: inputs are small integers, the kernel
+# accumulates in fp32 and the reference in fp64, both of which represent
+# these sums exactly.
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def matmul_padded_kernel(a_ptr, b_ptr, c_ptr, M, N, K,  #
+                         stride_am, stride_ak, stride_bk, stride_bn,  #
+                         stride_cm, stride_cn,  #
+                         A_OTHER: tl.constexpr, B_OTHER: tl.constexpr,  #
+                         BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                         BLOCK_K: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    rk = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + rm[:, None] * stride_am + rk[None, :] * stride_ak
+    b_ptrs = b_ptr + rk[:, None] * stride_bk + rn[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        k_rem = K - k * BLOCK_K
+        a = tl.load(a_ptrs, mask=rk[None, :] < k_rem, other=A_OTHER)
+        b = tl.load(b_ptrs, mask=rk[:, None] < k_rem, other=B_OTHER)
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c_ptrs = c_ptr + rm[:, None] * stride_cm + rn[None, :] * stride_cn
+    tl.store(c_ptrs, acc)
+
+
+def run_and_check(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, num_stages, device,
+                  a_other=0.0, b_other=0.0):
+    assert M % BLOCK_M == 0 and N % BLOCK_N == 0, "only K may be ragged"
+    torch.manual_seed(0)
+    a = torch.randint(-4, 5, (M, K), device=device).half()
+    b = torch.randint(-4, 5, (K, N), device=device).half()
+    c = torch.empty((M, N), device=device, dtype=torch.float32)
+    grid = (M // BLOCK_M, N // BLOCK_N)
+    matmul_padded_kernel[grid](
+        a, b, c, M, N, K,  #
+        a.stride(0), a.stride(1), b.stride(0), b.stride(1),  #
+        c.stride(0), c.stride(1),  #
+        A_OTHER=a_other, B_OTHER=b_other,  #
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
+        num_stages=num_stages)
+
+    # The kernel pads the last partial K tile with A_OTHER/B_OTHER via the
+    # load masks; replicate that padding exactly in the reference.
+    K_ceil = triton.cdiv(K, BLOCK_K) * BLOCK_K if K > 0 else 0
+    a_pad = torch.full((M, K_ceil), a_other, device=device, dtype=torch.float64)
+    b_pad = torch.full((K_ceil, N), b_other, device=device, dtype=torch.float64)
+    a_pad[:, :K] = a.double()
+    b_pad[:K, :] = b.double()
+    ref = a_pad @ b_pad
+
+    mismatched = (c.double() != ref).sum().item()
+    assert mismatched == 0, (
+        f"{mismatched}/{c.numel()} elements wrong for K={K} "
+        f"(trip count {triton.cdiv(K, BLOCK_K)}), num_stages={num_stages}")
+
+
+# Trip counts around and below the pipeline depth: the prologue prefetches
+# num_stages-1 tiles unconditionally (mask-predicated), so loops shorter than
+# the pipeline exercise stores of masked-off stages and epilogue draining.
+# K=33 adds a ragged final tile on top of a tiny trip count.
+@pytest.mark.parametrize("K", [0, 16, 32, 33, 64, 96, 160])
+@pytest.mark.parametrize("num_stages", [2, 3, 4])
+def test_edge_trip_counts(K, num_stages, device):
+    run_and_check(64, 64, K, 64, 64, 32, num_stages, device)
+
+
+# Multibuffer rotation with unique deterministic tiles: a single slot
+# collision corrupts an entire BLOCK_K contribution and fails the exact
+# compare. Shared memory: (64x32 + 32x64) fp16 = 8KB per stage, so even
+# num_stages=5 fits Turing's 64KB/CTA. Multiple CTAs via a 2x2 grid.
+@pytest.mark.parametrize("num_stages", [2, 3, 4, 5])
+def test_multibuffer_slot_rotation(num_stages, device):
+    run_and_check(128, 128, 640, 64, 64, 32, num_stages, device)
+
+
+# Non-zero `other` on masked loads: the sync path keeps the original tt.load
+# (mask and other included) as the data source, unlike the async path which
+# needs a select special-case. The padding contribution 3*2*pad_len is
+# replicated exactly by the padded reference.
+@pytest.mark.parametrize("K", [33, 80])
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_masked_load_nonzero_other(K, num_stages, device):
+    run_and_check(64, 64, K, 64, 64, 32, num_stages, device,
+                  a_other=3.0, b_other=2.0)


### PR DESCRIPTION
## Summary

GPU pytest stress suite for the sm75 synchronous-copy pipeline — the safety net required before relaxing AssignLatencies eligibility or deduplicating barriers (per the Codex review of #5/#6). Adds 29 parametrized cases with exact comparisons: inputs are small integers, the kernel accumulates in fp32 and the reference in fp64, so any single corrupted element fails deterministically instead of hiding inside an `allclose` tolerance.

## What it pins down

1. **Masked-off stages writing shared memory** (`test_edge_trip_counts`, trip counts 0/1/2/3/5 × num_stages 2/3/4, plus a ragged final K tile). `predicateOp` deliberately leaves `local_store` unpredicated, so prologue prefetches beyond the trip count write garbage into the buffer. These tests prove that garbage only ever lands in slots whose consumers are also masked off, and that zero-trip loops don't deadlock on the CTA barriers.

2. **Multibuffer slot rotation** (`test_multibuffer_slot_rotation`, num_stages 2–5 at 64×64×32 blocks, 8 KB/stage — still within the 64 KB/CTA limit at 5 stages). Unique deterministic tiles make an insert/extract slot collision corrupt an entire BLOCK_K contribution, turning a race that random fp16 data plus tolerances could easily hide into an exact mismatch. This restores multibuffering coverage lost when the 128-block `test_indirect_matmul` configurations were skipped on sm75.

3. **Mask + non-zero `other`** (`test_masked_load_nonzero_other`). The synchronous path keeps the original `tt.load` (with mask/other) alive as the data source, unlike the async path which requires a select special-case. The padded reference reproduces the `other` contribution exactly.

Runs on any CUDA architecture; on Ampere+ it exercises the async path as a bonus.

## Testing

* Turing (sm75): 29/29 pass in 18 s.
