### PR TITLE
perf: place one CTA barrier per stage group in sm75 sync copy

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -158,35 +158,106 @@ void createSyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   Operation *firstUse = getFirstUseOfPipelinedOp({loadOp}, forOp, schedule);
   assert(firstUse && "LoadOp has no users");
   OpBuilder::InsertionGuard guard(builder);
-  Location loc = loadOp.getLoc();
 
-  // consumer: local_load, then barrier to prevent producer overwrite.
-  // The original uses must be replaced before creating the local_store:
-  // replaceUsesWithLocalLoad rewrites all existing uses of loadOp, so a
-  // local_store created earlier would have its operand rewritten to the
-  // local_load result, losing the global load data.
+  // consumer: read the extract slot. The original uses must be replaced
+  // before creating the local_store: replaceUsesWithLocalLoad rewrites all
+  // existing uses of loadOp, so a local_store created earlier would have its
+  // operand rewritten to the local_load result, losing the global load data.
   builder.setInsertionPoint(firstUse);
   builder.setStageCluster(schedule[firstUse]);
   auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
-  auto localLoad =
-      replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad, nullptr);
-  // replaceUsesWithLocalLoad erases local_alloc users it folds into the
-  // pipeline buffer, which may include firstUse; anchor the barrier on ops we
-  // created ourselves instead of the (possibly dangling) insertion point.
-  if (localLoad)
-    builder.setInsertionPointAfter(localLoad);
-  else
-    builder.setInsertionPointAfter(viewLoad.getDefiningOp());
-  ttg::BarrierOp::create(builder, loc, ttg::AddrSpace::Local);
+  replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad, nullptr);
 
-  // producer: reg -> shared, then barrier. Unlike the async path, loadOp
-  // stays alive: the local_store consumes its result and PipelineExpander
-  // still needs its stage in the schedule.
+  // producer: reg -> shared. Unlike the async path, loadOp stays alive: the
+  // local_store consumes its result and PipelineExpander still needs its
+  // stage in the schedule. The CTA barriers synchronizing producer and
+  // consumer are emitted once per stage/cluster group in placeSyncBarriers
+  // after all loads are lowered.
   builder.setInsertionPointAfter(loadOp);
   builder.setStageCluster(schedule[loadOp]);
   Value view = createSingleBufferView(builder, alloc, insertIdx);
   ttg::LocalStoreOp::create(builder, loadOp.getResult(), view);
-  ttg::BarrierOp::create(builder, loc, ttg::AddrSpace::Local);
+}
+
+// Synchronization invariants for the sm75 synchronous copy pipeline (Turing
+// has no cp.async; data moves ld.global -> registers -> local_store):
+//
+//   INV-RAW: between a local_store filling a buffer slot and any read of
+//   that slot there must be at least one CTA barrier, so consumers never
+//   observe a partially written tile.
+//
+//   INV-WAR: between a read of a buffer slot and the local_store that next
+//   overwrites it there must be at least one CTA barrier, so producers never
+//   clobber a tile other warps are still reading. With double buffering the
+//   overwrite of the slot read by iteration i happens in iteration i itself,
+//   so the barrier after the reads is load-bearing even within one iteration.
+//
+// bar.sync is a CTA-wide fence over all of shared memory, not a per-buffer
+// lock: one barrier after the last write of a producer group orders all of
+// the group's writes against all later reads, and one barrier after the last
+// read of a consumer group orders all reads against all later writes. One
+// barrier per (stage, cluster) group is therefore sufficient, instead of two
+// per load: for a GEMM with A and B loads this means 2 barriers per
+// iteration instead of 4. The PipelineExpander stamps the same loop body
+// into the prologue, so the producer barrier also fences the prefill stores
+// against the first kernel iteration's reads.
+void placeSyncBarriers(scf::ForOp forOp, CoarseSchedule &schedule,
+                       const DenseSet<Value> &syncAllocs) {
+  auto traceToBase = [](Value v) {
+    while (Operation *def = v.getDefiningOp()) {
+      if (!def->hasTrait<OpTrait::MemDescViewTrait>())
+        break;
+      v = def->getOperand(0);
+    }
+    return v;
+  };
+
+  struct GroupInfo {
+    Operation *lastWrite = nullptr;
+    Operation *lastRead = nullptr;
+    std::pair<int, CoarseSchedule::Cluster> stageCluster;
+  };
+  llvm::MapVector<std::pair<int, int>, GroupInfo> groups;
+
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    bool writes = false, reads = false;
+    if (auto store = dyn_cast<ttg::LocalStoreOp>(&op)) {
+      writes = syncAllocs.contains(traceToBase(store.getDst()));
+    } else if (!op.hasTrait<OpTrait::MemDescViewTrait>()) {
+      // Pure views are transparent; any other op consuming a pipeline buffer
+      // (local_load, a dot reading operands from shared memory, ...) is a
+      // read that the WAR barrier must cover.
+      for (Value operand : op.getOperands()) {
+        if (isa<ttg::MemDescType>(operand.getType()) &&
+            syncAllocs.contains(traceToBase(operand)))
+          reads = true;
+      }
+    }
+    if (!writes && !reads)
+      continue;
+    auto it = schedule.find(&op);
+    if (it == schedule.end())
+      continue;
+    auto [stage, cluster] = it->second;
+    GroupInfo &group = groups[{stage, *cluster}];
+    group.stageCluster = it->second;
+    if (writes)
+      group.lastWrite = &op;
+    if (reads)
+      group.lastRead = &op;
+  }
+
+  OpBuilderForStage builder(forOp.getLoc(), forOp, schedule);
+  for (auto &[key, group] : groups) {
+    builder.setStageCluster(group.stageCluster);
+    for (Operation *anchor : {group.lastWrite, group.lastRead}) {
+      if (!anchor)
+        continue;
+      builder.setInsertionPointAfter(anchor);
+      ttg::BarrierOp::create(builder, anchor->getLoc(),
+                             ttg::AddrSpace::Local);
+    }
+  }
 }
 
 void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
@@ -630,12 +701,14 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
   createTMABarrierAndWait(forOp, asyncLoads, loadGroups, schedule);
 
   bool hasAsyncLoads = false;
+  DenseSet<Value> syncAllocs;
   for (auto [op, asyncLoad] : asyncLoads) {
     auto [insertIdx, extractIdx, phase, _] = loadGroups[asyncLoad.stageDiff];
     if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
       if (computeCapability == 75) {
         createSyncCopy(forOp, loadOp, asyncLoad.alloc, insertIdx, extractIdx,
                        schedule);
+        syncAllocs.insert(asyncLoad.alloc);
       } else {
         createAsyncCopy(forOp, loadOp, asyncLoad.alloc, insertIdx, extractIdx,
                         asyncLoad.contiguity, schedule);
@@ -659,6 +732,9 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
     if (loadGroup.phase)
       forYield.setOperand(argIdx++, loadGroup.phase);
   }
+
+  if (!syncAllocs.empty())
+    placeSyncBarriers(forOp, schedule, syncAllocs);
 
   // Automatically discover dependencies and schedule new insert/extract ops to
   // correct stages.

--- a/test/TritonGPU/sm75-sync-copy-lower-loop.mlir
+++ b/test/TritonGPU/sm75-sync-copy-lower-loop.mlir
@@ -44,6 +44,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.targ
 // consumer reads the buffer view directly, no local_load is created, and the
 // original local_alloc disappears. This path used to crash with a dangling
 // insertion point because the alloc (the load's first use) is erased.
+// The consumer barrier must come after the read of the buffer (WAR: the slot
+// may not be overwritten while other warps still read it), which here is the
+// "use" op consuming the view directly.
 // CHECK-LABEL: @sync_copy_local_alloc_user
 // CHECK: %[[ALLOC:.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x128x32
 // CHECK: scf.for
@@ -53,8 +56,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.targ
 // CHECK:   %[[EXT:.*]] = ttg.memdesc_index %[[ALLOC]]{{\[}}%{{.*}}{{\]}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK-NOT: ttg.local_load
 // CHECK-NOT: ttg.local_alloc
-// CHECK:   ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   "use"(%[[EXT]])
+// CHECK-NEXT: ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 tt.func @sync_copy_local_alloc_user(%lb : index, %ub : index, %step : index,
                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -94,6 +97,40 @@ tt.func @sync_copy_three_stages(%lb : index, %ub : index, %step : index,
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 3 : i32} : (tensor<128x32xf16, #A>) -> ()
   } {tt.scheduled_max_stage = 3 : i32}
+  tt.return
+}
+}
+
+// -----
+
+#A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// bar.sync is a CTA-wide fence over all of shared memory, so loads sharing a
+// stage/cluster share one producer barrier (after the last local_store) and
+// one consumer barrier (after the last read) instead of one pair per load:
+// 2 barriers per iteration for a GEMM-shaped loop, not 4.
+// CHECK-LABEL: @sync_copy_two_loads_share_barriers
+// CHECK: scf.for
+// CHECK:   ttg.local_store
+// CHECK-NOT: ttg.barrier
+// CHECK:   ttg.local_store
+// CHECK-NEXT: ttg.barrier local {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK-NOT: ttg.barrier
+// CHECK:   ttg.local_load
+// CHECK-NOT: ttg.barrier
+// CHECK:   ttg.local_load
+// CHECK-NEXT: ttg.barrier local {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK-NOT: ttg.barrier
+// CHECK:   "use"
+tt.func @sync_copy_two_loads_share_barriers(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                 %b_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    %b = tt.load %b_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
+    "use"(%a, %b) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>, tensor<128x32xf16, #A>) -> ()
+  } {tt.scheduled_max_stage = 2 : i32}
   tt.return
 }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p><code inline="">createSyncCopy</code> previously emitted one producer and one consumer barrier for every load, resulting in four <code inline="">bar.sync</code>s per iteration in GEMM (A and B loads). Since <code inline="">bar.sync</code> is a CTA-wide fence over all shared memory rather than a per-buffer lock, only one barrier after the last write of a producer group and one barrier after the last read of a consumer group are required. This change reduces synchronization to two barriers per iteration.</p><h2>Design</h2><p>Barrier emission is moved out of <code inline="">createSyncCopy</code> and centralized in <code inline="">placeSyncBarriers</code>, which runs after all loads have been lowered. The pass walks the loop body, classifies pipeline-buffer accesses by tracing <code inline="">memdesc</code> views back to their allocs, treats any non-view consumer of a buffer as a read, groups accesses by <code inline="">(stage, cluster)</code>, and inserts a single barrier after the last write and the last read of each group. As a result, <code inline="">createSyncCopy</code> no longer emits barriers and no longer needs insertion-point management.</p><p>The synchronization rules are documented explicitly:</p><ul><li><p><strong>INV-RAW</strong>: a <code inline="">local_store</code> filling a slot and any read of that slot must be separated by at least one CTA barrier.</p></li><li><p><strong>INV-WAR</strong>: a read of a slot and the <code inline="">local_store</code> that next overwrites it must be separated by at least one CTA barrier. With double buffering, the overwrite occurs within the same iteration, making the post-read barrier necessary every iteration.</p></li></ul><h2>Correctness Fix</h2><p>The local_alloc-elision path used by real GEMMs previously placed the consumer barrier before the operation reading the buffer view, leaving the read unfenced against the same-slot overwrite and violating INV-WAR. The issue was largely hidden by global memory latency. Consumer barriers are now always placed after the reads they protect.</p><h2>Testing</h2><ul><li><p>lit: 280/280 passed.</p></li><li><p>Existing single-load tests also serve as regressions against over-deduplication.</p></li><li><p>Added a new two-load lit test to verify exactly one barrier per group (<code inline="">CHECK-NOT</code> between accesses and <code inline="">CHECK-NEXT</code> after the final access).</p></li><li><p>Turing GPU:</p><ul><li><p>stress suite: 29/29 exact-match passes;</p></li><li><p><code inline="">test_pipeliner</code>: 23 passed, 13 skipped;</p></li><li><p>GEMM tutorial fp16 and fp8 outputs match PyTorch.</p></li></ul></li></ul><h2>Performance (RTX Turing, fp16 GEMM vs cuBLAS)</h2>
size | before (TFLOPS) | after (TFLOPS) | delta
-- | -- | -- | --
1536³ | 35.5 | 43.2 | +22%
2048³ | 32.9 | 41.2 | +25%
3072³ | 37.4 | 47.9 | +28%
4096³ | 36.1 | 46.5 | +29%

<p>The cuBLAS ratio improves from roughly 45% to 57–58%. FP8 shows similar gains, with minor run-to-run variation at the largest sizes due to thermal effects.</p></body></html><!--EndFragment-->
</body>
</html>