### PR TITLE
perf: add Turing-specific GEMM autotune config space

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -213,8 +213,47 @@ def get_hip_autotune_config():
     return [triton.Config(s | {'matrix_instr_nonkdim': 16}, num_warps=8, num_stages=2) for s in sizes]
 
 
+def get_turing_autotune_config():
+    # Turing (sm75): 64KB shared memory per CTA and a synchronous-copy
+    # pipeline (no cp.async), so the Ampere-oriented configs above mostly
+    # exceed the budget: (BM + BN) * BK * 2B * num_stages <= 64KB. Every
+    # config with a >= 128x128 tile gets pruned there, leaving only small
+    # tiles with poor compute/memory ratios. This space keeps tiles large
+    # and stages shallow instead, and includes deep-K single-stage points
+    # (the cudaTensorCoreGemm design: amortize barriers over a deep chunk).
+    sizes = [
+        # large tiles, shallow pipeline
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 3, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 8},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 8},
+        {'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 8},
+        # deeper K, fewer stages
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'num_stages': 1, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'num_stages': 1, 'num_warps': 8},
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'num_stages': 2, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64, 'num_stages': 2, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'num_stages': 3, 'num_warps': 4},
+        # medium tiles, mid-depth pipeline
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'num_stages': 3, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 3, 'num_warps': 4},
+        # small matrices
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 4},
+        {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 2},
+        {'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 2},
+    ]
+    return [
+        triton.Config(
+            {k: v for k, v in s.items() if k.startswith('BLOCK')} | {'GROUP_SIZE_M': 8},
+            num_stages=s['num_stages'], num_warps=s['num_warps'])
+        for s in sizes
+    ]
+
+
 def get_autotune_config():
     if is_cuda():
+        if torch.cuda.get_device_capability() == (7, 5):
+            return get_turing_autotune_config()
         return get_cuda_autotune_config()
     else:
         return get_hip_autotune_config()


### PR DESCRIPTION
## Problem

The tutorial's autotune configs were written for Ampere (164KB shared memory + `cp.async`). On Turing, multibuffering costs `(BM + BN) × BK × 2B × num_stages` out of a 64KB/CTA hard cap, which silently prunes every config with a tile ≥ 128×128 at compile time. As a result, the autotuner was only choosing among small tiles with poor compute/memory ratios. This, rather than the pipeline itself, was the main remaining gap to cuBLAS.

## Change

Add `get_turing_autotune_config()`, dispatched on capability `(7, 5)`, providing 15 configs that keep tiles large and pipelines shallow while staying within the 64KB shared-memory budget.

The search space intentionally includes two design philosophies:

- **Large tile + shallow pipeline** (e.g. `128×128`, `BK=32`, `num_stages=2-3`)
- **Deep-K single-stage** (e.g. `128×128`, `BK=64`, `num_stages=1`), modeled after NVIDIA's `cudaTensorCoreGemm` sample, which amortizes the two CTA barriers over a deeper K chunk instead of relying on overlap.

## Results (fp16, Turing, vs benchmarks/gemm/08)

| size | before | after | delta | vs cuBLAS |
|-------|--------:|-------:|-------:|-----------:|
| 1536³ | 43.2 | 60.6 | +40% | 81% |
| 1792³ | 41.3 | 53.7 | +30% | 97% |
| 2048³ | 41.2 | 59.0 | +43% | 79% |
| 2304³ | 43.1 | 58.2 | +35% | 90% |
| 3072³ | 47.9 | 68.4 | +43% | 79% |

Across 31 benchmark shapes, the winner distribution is:

- 15× `128×128 / BK=32 / num_stages=3 / num_warps=4` (the exact tile size the old search space never got to try)
- 6× deep-K single-stage configs
- the remainder from smaller-shape configs

Both design philosophies contribute meaningfully to the final performance.

Benchmark data and full autotune logs are available under `benchmarks/gemm/09/`.

**Note:** rows ≥ 3328 are thermally throttled. Both cuBLAS and Triton degrade together, so clean tail numbers require a locked-clock rerun.

## Also verified (not included in this diff)

- int8 Tensor Core MMA ignition on sm75: `mma.m8n8k16` (`s8 × s8 → s32`) is emitted and produces exact results for `num_stages = 1/2/3`, including the sync-copy pipeline configuration.