### PR TITLE
feat: admit narrow loads to the sm75 pipeline

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -99,6 +99,11 @@ std::pair<Operation *, int64_t> getDefiningOpAndDistance(scf::ForOp forOp,
 int getCopyVecBytes(RankedTensorType registerTy,
                     gpu::SharedEncodingTrait sharedEnc);
 
+// Contiguous access width of the load in bits (pointer contiguity, capped by
+// mask alignment, times the element width).
+unsigned getLoadContiguousBits(
+    triton::LoadOp loadOp, triton::ModuleAxisInfoAnalysis &axisInfoAnalysis);
+
 bool canBeConvertedToAsyncLoad(
     triton::LoadOp loadOp, triton::ModuleAxisInfoAnalysis &axisInfoAnalysis);
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -23,7 +23,8 @@ bool isSafeToPipeline(scf::ForOp forOp);
 llvm::MapVector<Operation *, std::pair<int, Operation *>>
 loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                           triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                          int numStages, bool filterSmall = true);
+                          int numStages, bool filterSmall = true,
+                          int computeCapability = 0);
 
 }; // namespace gpu
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -71,7 +71,8 @@ public:
 
     llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
         loadOpsToIndirectionLevel(forOp, pipelineWithoutDot, axisInfoAnalysis,
-                                  numStages);
+                                  numStages, /*filterSmall=*/true,
+                                  computeCapability);
     if (loadOpToIndLevel.empty())
       return;
 
@@ -180,9 +181,18 @@ public:
   static bool
   isPipeliningBeneficial(Operation *op, Operation *finalUser,
                          tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                         bool filterSmall) {
+                         bool filterSmall, int computeCapability = 0) {
+    // The >= 4-byte floor below is cp.async's minimum transfer size. The
+    // sm75 synchronous copy path has no such hardware constraint, so on
+    // Turing only a profitability floor of one 16-bit element remains:
+    // pipelining strided fp16 loads (contiguity 1) is still worthwhile
+    // because their long latency is exactly what overlapping hides.
+    bool sm75SyncCopy = computeCapability == 75;
     if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
-      if (filterSmall && !canBeConvertedToAsyncLoad(loadOp, axisInfoAnalysis)) {
+      if (filterSmall &&
+          (sm75SyncCopy
+               ? getLoadContiguousBits(loadOp, axisInfoAnalysis) < 16
+               : !canBeConvertedToAsyncLoad(loadOp, axisInfoAnalysis))) {
         LDBG("Load " << *loadOp << " is too small for pipelining");
         return false;
       }
@@ -218,8 +228,9 @@ public:
     if (localAllocEnc) {
       auto registerTy = cast<RankedTensorType>(op->getResultTypes()[0]);
       auto vecBytes = getCopyVecBytes(registerTy, localAllocEnc);
-      if (filterSmall && vecBytes < 4) {
-        // At least 4 bytes need to be consecutive for cp.async
+      // At least 4 consecutive bytes for cp.async; the sm75 sync copy only
+      // needs a whole 16-bit element per st.shared.
+      if (filterSmall && vecBytes < (sm75SyncCopy ? 2 : 4)) {
         return false;
       }
     }
@@ -370,7 +381,8 @@ void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
 llvm::MapVector<Operation *, std::pair<int, Operation *>>
 loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                           tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                          int numStages, bool filterSmall) {
+                          int numStages, bool filterSmall,
+                          int computeCapability) {
   llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel;
   DenseSet<Operation *> seen;
   DenseSet<Operation *> excluded;
@@ -381,7 +393,8 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
           return;
         if (isa<tt::LoadOp, tt::DescriptorLoadLikeOpInterface>(op)) {
           if (!AssignLoadLatencies::isPipeliningBeneficial(
-                  op, finalUser, axisInfoAnalysis, filterSmall))
+                  op, finalUser, axisInfoAnalysis, filterSmall,
+                  computeCapability))
             return;
           if (loadOpToIndLevel.count(op)) {
             int level = loadOpToIndLevel[op].first;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -294,7 +294,7 @@ int mlir::triton::getCopyVecBytes(RankedTensorType registerTy,
   return vecElems * registerTy.getElementTypeBitWidth() / 8;
 }
 
-bool mlir::triton::canBeConvertedToAsyncLoad(
+unsigned mlir::triton::getLoadContiguousBits(
     tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   auto ptr = loadOp.getPtr();
   unsigned vec = axisInfoAnalysis.getContiguity(ptr);
@@ -302,21 +302,23 @@ bool mlir::triton::canBeConvertedToAsyncLoad(
     vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
 
   auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
-  unsigned width = 0;
   if (tensorTy) {
     auto ty = cast<tt::PointerType>(tensorTy.getElementType()).getPointeeType();
-    width = vec * ty.getIntOrFloatBitWidth();
-  } else {
-    width = cast<tt::PointerType>(ptr.getType())
-                .getPointeeType()
-                .getIntOrFloatBitWidth();
+    return vec * ty.getIntOrFloatBitWidth();
   }
+  return cast<tt::PointerType>(ptr.getType())
+      .getPointeeType()
+      .getIntOrFloatBitWidth();
+}
 
+bool mlir::triton::canBeConvertedToAsyncLoad(
+    tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   // We do not pipeline all loads for the following reasons:
   // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
   // 2. It's likely that pipling small loads won't offer much performance
   //    improvement and may even hurt performance by increasing register
   //    pressure.
+  unsigned width = getLoadContiguousBits(loadOp, axisInfoAnalysis);
   LDBG("Load " << *loadOp << " has width " << width);
   return width >= 32;
 }

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -1324,3 +1324,64 @@ tt.func @sm75_static_alloc_shrinks_budget(%lb : index, %ub : index, %step : inde
   tt.return %loop#2: tensor<128x128xf32, #C>
 }
 }
+
+// -----
+
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#C = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=2}>
+#B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
+#AI = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=4}>
+#BI = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=4}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:75"} {
+// The >= 4-byte floor in canBeConvertedToAsyncLoad is cp.async's minimum
+// transfer size. The sm75 sync copy path has no such constraint, so a
+// contiguity-1 fp16 load (16 bits) - rejected upstream, see @small_load -
+// is pipelined on Turing.
+// CHECK-LABEL: @sm75_small_load_pipelined
+tt.func @sm75_small_load_pipelined(%lb : index, %ub : index, %step : index,
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL>) -> tensor<128x128xf32, #C> {
+  %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
+  %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
+  %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
+  %loop:3 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init) -> (tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>) {
+    // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+    %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
+    %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
+    // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+    %b_ = tt.load %b_ptr : tensor<32x128x!tt.ptr<f16>, #BL>
+    %b = ttg.convert_layout %b_ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B>
+    %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16, #A> * tensor<32x128xf16, #B> -> tensor<128x128xf32, #C>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    scf.yield %next_a_ptr, %next_b_ptr, %c : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>
+  }
+  tt.return %loop#2: tensor<128x128xf32, #C>
+}
+
+// Sub-element widths stay rejected even on sm75: contiguity-1 i8 loads
+// (8 bits) fall below the 16-bit profitability floor.
+// CHECK-LABEL: @sm75_subelement_load_not_pipelined
+// CHECK-NOT: tt.latency
+tt.func @sm75_subelement_load_not_pipelined(%lb : index, %ub : index, %step : index,
+                  %a_ptr_init : tensor<128x32x!tt.ptr<i8>, #AL>,
+                  %b_ptr_init : tensor<32x128x!tt.ptr<i8>, #BL>) -> tensor<128x128xi32, #C> {
+  %c_init = arith.constant dense<0> : tensor<128x128xi32, #C>
+  %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
+  %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
+  %loop:3 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init) -> (tensor<128x32x!tt.ptr<i8>, #AL>, tensor<32x128x!tt.ptr<i8>, #BL>, tensor<128x128xi32, #C>) {
+    %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<i8>, #AL>
+    %a = ttg.convert_layout %a_ : tensor<128x32xi8, #AL> -> tensor<128x32xi8, #AI>
+    %b_ = tt.load %b_ptr : tensor<32x128x!tt.ptr<i8>, #BL>
+    %b = ttg.convert_layout %b_ : tensor<32x128xi8, #BL> -> tensor<32x128xi8, #BI>
+    %c = tt.dot %a, %b, %prev_c : tensor<128x32xi8, #AI> * tensor<32x128xi8, #BI> -> tensor<128x128xi32, #C>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off : tensor<128x32x!tt.ptr<i8>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<i8>, #BL>, tensor<32x128xi32, #BL>
+    scf.yield %next_a_ptr, %next_b_ptr, %c : tensor<128x32x!tt.ptr<i8>, #AL>, tensor<32x128x!tt.ptr<i8>, #BL>, tensor<128x128xi32, #C>
+  }
+  tt.return %loop#2: tensor<128x128xi32, #C>
+}
+}


### PR DESCRIPTION
## Problem

`canBeConvertedToAsyncLoad` rejected loads narrower than 32 contiguous bits (`contiguity × element width`). That threshold is `cp.async`'s minimum transfer size, which is a hardware constraint of the async path. On sm75, however, the synchronous copy path (`ld.global` + `st.shared`) can move any width, but the same filter still kept strided/transposed fp16 loads out of the pipeline when `contiguity = 1`, producing only 16 contiguous bits. These are exactly the loads that benefit most from pipelining, because uncoalesced access has the longest latency and the pipeline is intended to hide long latency.

## Change

Correctness eligibility and profitability are now separated, following the Codex review of the pipeline plan.

- For sm75, the `cp.async` rule is replaced by a profitability floor of one 16-bit element: `getLoadContiguousBits >= 16`. Sub-element loads, such as contiguity-1 i8, remain rejected. The shared-side copy vector floor is reduced from 4 bytes to 2 bytes accordingly.
- For all other targets, behavior is unchanged. `loadOpsToIndirectionLevel` now takes a defaulted `computeCapability` parameter, so AMD callers are unaffected.
- The width computation is moved into a shared helper, `getLoadContiguousBits`, which is used by both rules.
- Newly admitted loads still go through the shared-memory latency clamp like other loads, so this relaxation cannot reintroduce `OutOfResources`.

## Testing

- `lit`: 280/280 passed.
- Added two boundary tests: a contiguity-1 fp16 load, previously rejected upstream in `@small_load`, now gets `tt.latency = 2` on sm75; a contiguity-1 i8 load still gets no latency annotation.
- Turing GPU stress suite: 29/29 passed.
- `test_pipeliner`: 23 passed / 13 skipped.
- GEMM fp16 result matches `benchmarks/gemm/09`.

## Expectations

Current benchmarks are high-contiguity and intentionally unaffected. The expected beneficiaries are transposed and strided kernels, such as `A @ B.T`-style GEMMs and attention variants that read K/V off the major axis. Coverage for those cases will land with the benchmark system work.