### PR TITLE
perf: pipeline-aware Turing autotune (GEMM s1 + d128 attn bwd s2)

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -222,7 +222,12 @@ def get_turing_autotune_config():
     # and stages shallow instead, and includes deep-K single-stage points
     # (the cudaTensorCoreGemm design: amortize barriers over a deep chunk).
     sizes = [
-        # large tiles, shallow pipeline
+        # large tiles. On large square GEMM the sync-copy pipeline is a net
+        # loss: the kernel is compute-bound (Tensor Core ~71% even at s1) and
+        # load latency is already hidden by ptxas register-level scheduling, so
+        # the single-buffer num_stages=1 point below wins (~+5% vs s3). The
+        # s2/s3 variants stay for smaller/latency-exposed shapes.
+        {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 1, 'num_warps': 4},
         {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 4},
         {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 3, 'num_warps': 4},
         {'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'num_stages': 2, 'num_warps': 8},

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -588,15 +588,15 @@ class _attention(torch.autograd.Function):
         BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
         if is_cuda() and torch.cuda.get_device_capability() == (7, 5):
             # Turing: 64KB shared memory per CTA (Ampere+: >= 100KB). At
-            # HEAD_DIM=128 the dot operand staging of the upstream block
-            # sizes alone needs ~80KB, so halve the K/V (resp. Q) row blocks
-            # and skip pipelining. At HEAD_DIM=64 the upstream blocks fit
-            # with a double-buffered pipeline.
-            if ctx.HEAD_DIM <= 64:
-                NUM_STAGES = 2
-            else:
-                NUM_STAGES = 1
+            # HEAD_DIM=128 the upstream block sizes need ~80KB, so halve the
+            # K/V (resp. Q) row blocks to fit. A 2-stage pipeline still fits at
+            # the halved sizes and beats single-buffer by ~11% -- the softmax-
+            # gradient dependency chain exposes latency the pipeline hides
+            # (verified vs SDPA grads; same mechanism as the forward). HEAD_DIM
+            # <= 64 keeps the upstream blocks with the same 2-stage pipeline.
+            if ctx.HEAD_DIM > 64:
                 BLOCK_N1, BLOCK_M2 = 64, 64
+            NUM_STAGES = 2
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
         arg_k = k


### PR DESCRIPTION
## Problem

Two Turing (sm75) configs were leaving performance on the table because of assumptions about the sync-copy pipeline that controlled experiments disproved:

1. **GEMM**: the Turing autotune space only offered `num_stages>=2` for the `128x128x32` tile, forcing a pipelined winner. But large square GEMM is compute-bound: Tensor Core utilization is already ~71% even at `num_stages=1`, and load latency is hidden by ptxas register-level scheduling, so the sync-copy pipeline is a net loss.
2. **Attention d128 backward**: this was capped at `num_stages=1` on the assumption that the halved Turing block sizes left no room to pipeline.

## Changes

- `03-matrix-multiplication.py`: add the `128x128x32, num_stages=1` single-buffer config to the Turing autotune space. The autotuner now picks it on large square GEMM for **~+5%**, and it wins at every tested size from 1536 to 4096.
- `06-fused-attention.py`: enable `num_stages=2` for d128 backward while keeping the halved `BLOCK_N1/M2=64`. A 2-stage pipeline fits in 64KB and gives **~+11%** on N4096, improving from 20.8 to 23.1 TFLOPS. The softmax-gradient dependency chain exposes latency that the pipeline hides, matching the mechanism that benefits forward.

Both changes are Python-only config updates and require no compiler changes or rebuild.

## Testing

- GEMM: autotune confirms `num_stages=1` wins at every tested size; `torch.matmul` allclose ✓.
- Attention d128 backward: `dq`, `dk`, and `dv` allclose against PyTorch SDPA gradients with maxdiff 2e-3 ✓; forward allclose ✓.
- Background: a full pipeline-value study shows GEMM gets no benefit, while FA2 gets +9–48% and grouped attention gets +20%, motivating both changes. FA2 forward and d64 backward already beat hand-written CUDA (`ssiu/flash-attention-turing`) on Turing.